### PR TITLE
[BUGFIX] Allow extension installation

### DIFF
--- a/Classes/Service/SqlSchemaMigrationService.php
+++ b/Classes/Service/SqlSchemaMigrationService.php
@@ -18,7 +18,7 @@ namespace TYPO3\CMS\Dbal\Service;
  * XCLASS of ext:install SqlSchemaMigrationService containing
  * a couple of ext:dbal specifics.
  */
-class SqlSchemaMigrationService
+class SqlSchemaMigrationService extends \TYPO3\CMS\Install\Service\SqlSchemaMigrationService
 {
     /**
      * @constant Maximum field width of MySQL


### PR DESCRIPTION
EXT:dbal defines an own xclass for the core class
\TYPO3\CMS\Install\Service\SqlSchemaMigrationService. This core class
is used to install extensions in
\TYPO3\CMS\Extensionmanager\Utility\InstallUtility. The InstallUtility
needs an own instance of the SqlSchemaMigrationService. Therefore an
inject function is used to inject the dependency. But the inject
method has a type hint to
\TYPO3\CMS\Install\Service\SqlSchemaMigrationService. Using dbals's
xclass results in an exception.

Resolves: #3 