### PR TITLE
[TASK] Update composer.json license definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ jobs:
       php: 7
 
     - stage: publish to ter
+      if: tag IS present
       php: 7.1
       before_install: skip
       install: skip

--- a/Classes/Database/AdodbPreparedStatement.php
+++ b/Classes/Database/AdodbPreparedStatement.php
@@ -189,13 +189,9 @@ class AdodbPreparedStatement extends \TYPO3\CMS\Dbal\Database\DatabaseConnection
             $this->recordSet = $this->databaseConnection->handlerInstance[$this->databaseConnection->lastHandlerKey]->_Execute($this->databaseConnection->lastQuery);
         }
 
-        if ($this->recordSet !== false) {
-            $success = true;
+        $success = $this->recordSet !== false;
+        if ($success) {
             $this->recordSet->TYPO3_DBAL_handlerType = 'adodb';
-            // Setting handler type in result object (for later recognition!)
-            //$this->recordSet->TYPO3_DBAL_tableList = $queryComponents['ORIG_tableName'];
-        } else {
-            $success = false;
         }
 
         return $success;

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"type": "typo3-cms-extension",
 	"description": "A database abstraction layer implementation for TYPO3 4.6+ based on ADOdb and offering a lot of other features.",
 	"homepage": "https://typo3.org",
-	"license": ["GPL-2.0+"],
+	"license": "GPL-2.0-or-later",
 	"require": {
 		"typo3/cms-core": "~8.4",
 		"friendsoftypo3/adodb": "~8.4"


### PR DESCRIPTION
Composer license definition GPL-2.0+ has been deprecated and has to be
replaced with GPL-2.0-or-later.